### PR TITLE
use generics

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.18
 
     - name: Build
       run: make

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 strdiff
+intdiff

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
-strdiff: *.go examples/strdiff.go
+all: *.go examples/*.go
+	go build -o strdiff examples/strdiff.go
+	go build -o intdiff examples/intdiff.go
+
+strdiff: *.go
 	go build -o $@ examples/strdiff.go
+
+intdiff: *.go examples/intdiff.go
+	go build -o $@ examples/intdiff.go
 
 fmt:
 	go fmt ./...
@@ -8,4 +15,6 @@ check:
 	go test -v ./...
 
 clean:
-	rm -f strdiff
+	rm -f strdiff intdiff
+
+.PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ fmt:
 	go fmt ./...
 
 check:
-	go test -v ./...
+	go test -v .
 
 clean:
 	rm -f strdiff intdiff

--- a/README.md
+++ b/README.md
@@ -13,18 +13,37 @@ The computational complexity of Wu's O(NP) Algorithm is averagely O(N+PD), in th
 
 # Getting started
 
+## strdiff
+
 ```go
-diff := gonp.New("abc", "abd")
+diff := gonp.New[rune]([]rune("abc"), []rune("abd"))
 diff.Compose()
 ed := diff.Editdistance() // ed is 2
 lcs := diff.Lcs() // lcs is "ab"
 
 ses := diff.Ses()
 // ses is []SesElem{
-//        {c: 'a', t: Common},
-//        {c: 'b', t: Common},
-//        {c: 'c', t: Delete},
-//        {c: 'd', t: Add},
+//        {e: 'a', t: Common},
+//        {e: 'b', t: Common},
+//        {e: 'c', t: Delete},
+//        {e: 'd', t: Add},
+//        }
+```
+
+## intdiff
+
+```go
+diff := gonp.New[int]([]int{1,2,3}, []int{1,5,3})
+diff.Compose()
+ed := diff.Editdistance() // ed is 2
+lcs := diff.Lcs() // lcs is [1,3]
+
+ses := diff.Ses()
+// ses is []SesElem{
+//        {e: 1, t: Common},
+//        {e: 2, t: Delete},
+//        {e: 5, t: Add},
+//        {e: 3, t: Common},
 //        }
 ```
 

--- a/examples/intdiff.go
+++ b/examples/intdiff.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/cubicdaiya/gonp"
+)
+
+func main() {
+	a := []int{1, 2, 3, 4, 5}
+	b := []int{1, 2, 9, 4, 5}
+	diff := gonp.New[int](a, b)
+	diff.Compose()
+	fmt.Printf("Editdistance: %d\n", diff.Editdistance())
+	fmt.Printf("LCS: %v\n", diff.Lcs())
+	fmt.Println("SES:")
+	diff.PrintSes()
+}

--- a/examples/strdiff.go
+++ b/examples/strdiff.go
@@ -19,5 +19,5 @@ func main() {
 	fmt.Printf("Editdistance: %d\n", diff.Editdistance())
 	fmt.Printf("LCS: %s\n", string(diff.Lcs()))
 	fmt.Println("SES:")
-	diff.PrintSesString()
+	diff.PrintSesRune()
 }

--- a/examples/strdiff.go
+++ b/examples/strdiff.go
@@ -12,10 +12,12 @@ func main() {
 	if len(os.Args) < 3 {
 		log.Fatal("./strdiff arg1 arg2")
 	}
-	diff := gonp.New(os.Args[1], os.Args[2])
+	a := []rune(os.Args[1])
+	b := []rune(os.Args[2])
+	diff := gonp.New[rune](a, b)
 	diff.Compose()
 	fmt.Printf("Editdistance: %d\n", diff.Editdistance())
-	fmt.Printf("LCS: %s\n", diff.LcsString())
+	fmt.Printf("LCS: %s\n", string(diff.Lcs()))
 	fmt.Println("SES:")
-	diff.PrintSes()
+	diff.PrintSesString()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/cubicdaiya/gonp
 
-go 1.15
+go 1.18

--- a/gonp.go
+++ b/gonp.go
@@ -124,17 +124,17 @@ func (diff *Diff[T]) FprintSes(w io.Writer) {
 	}
 }
 
-// PrintSesString prints shortest edit script string between a and b
-func (diff *Diff[T]) PrintSesString() {
+// PrintSesRune prints shortest edit script rune between a and b
+func (diff *Diff[T]) PrintSesRune() {
 	var buf bytes.Buffer
 	for _, e := range diff.ses {
 		switch e.t {
 		case SesDelete:
-			fmt.Fprintf(&buf, "- %v\n", string(e.e))
+			fmt.Fprintf(&buf, "- %c\n", e.e)
 		case SesAdd:
-			fmt.Fprintf(&buf, "+ %v\n", string(e.e))
+			fmt.Fprintf(&buf, "+ %c\n", e.e)
 		case SesCommon:
-			fmt.Fprintf(&buf, "  %v\n", string(e.e))
+			fmt.Fprintf(&buf, "  %c\n", e.e)
 		}
 	}
 	fmt.Print(buf.String())

--- a/gonp_test.go
+++ b/gonp_test.go
@@ -216,5 +216,12 @@ func TestDiffSprintSes(t *testing.T) {
 	diff := New[rune](a, b)
 	diff.Compose()
 	ses := diff.SprintSes()
-	assert(t, ses == "  a\n  \n\n- b\n+ 1\n  \n\n  c\n")
+	expected := `  97
+  10
+- 98
++ 49
+  10
+  99
+`
+	assert(t, ses == expected)
 }

--- a/gonp_test.go
+++ b/gonp_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func equalsSesElemArray(ses1, ses2 []SesElem) bool {
+func equalsSesElemArray[T Elem](ses1, ses2 []SesElem[T]) bool {
 	m, n := len(ses1), len(ses2)
 	if m != n {
 		return true
@@ -24,11 +24,13 @@ func assert(t *testing.T, b bool) {
 }
 
 func TestDiff1(t *testing.T) {
-	diff := New("abc", "abd")
+	a := []rune("abc")
+	b := []rune("abd")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{
+	sesExpected := []SesElem[rune]{
 		{e: 'a', t: SesCommon},
 		{e: 'b', t: SesCommon},
 		{e: 'c', t: SesDelete},
@@ -40,11 +42,13 @@ func TestDiff1(t *testing.T) {
 }
 
 func TestDiff2(t *testing.T) {
-	diff := New("abcdef", "dacfea")
+	a := []rune("abcdef")
+	b := []rune("dacfea")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{
+	sesExpected := []SesElem[rune]{
 		{e: 'd', t: SesAdd},
 		{e: 'a', t: SesCommon},
 		{e: 'b', t: SesDelete},
@@ -61,11 +65,13 @@ func TestDiff2(t *testing.T) {
 }
 
 func TestDiff3(t *testing.T) {
-	diff := New("acbdeacbed", "acebdabbabed")
+	a := []rune("acbdeacbed")
+	b := []rune("acebdabbabed")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{
+	sesExpected := []SesElem[rune]{
 		{e: 'a', t: SesCommon},
 		{e: 'c', t: SesCommon},
 		{e: 'e', t: SesAdd},
@@ -87,11 +93,13 @@ func TestDiff3(t *testing.T) {
 }
 
 func TestDiff4(t *testing.T) {
-	diff := New("abcbda", "bdcaba")
+	a := []rune("abcbda")
+	b := []rune("bdcaba")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{
+	sesExpected := []SesElem[rune]{
 		{e: 'a', t: SesDelete},
 		{e: 'b', t: SesCommon},
 		{e: 'd', t: SesAdd},
@@ -107,11 +115,13 @@ func TestDiff4(t *testing.T) {
 }
 
 func TestDiff5(t *testing.T) {
-	diff := New("bokko", "bokkko")
+	a := []rune("bokko")
+	b := []rune("bokkko")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{
+	sesExpected := []SesElem[rune]{
 		{e: 'b', t: SesCommon},
 		{e: 'o', t: SesCommon},
 		{e: 'k', t: SesCommon},
@@ -125,22 +135,26 @@ func TestDiff5(t *testing.T) {
 }
 
 func TestDiffEmptyString1(t *testing.T) {
-	diff := New("", "")
+	a := []rune("")
+	b := []rune("")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{}
+	sesExpected := []SesElem[rune]{}
 	assert(t, diff.Editdistance() == 0)
 	assert(t, lcs == "")
 	assert(t, equalsSesElemArray(sesActual, sesExpected))
 }
 
 func TestDiffEmptyString2(t *testing.T) {
-	diff := New("a", "")
+	a := []rune("a")
+	b := []rune("")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{
+	sesExpected := []SesElem[rune]{
 		{e: 'a', t: SesDelete},
 	}
 	assert(t, diff.Editdistance() == 1)
@@ -149,11 +163,13 @@ func TestDiffEmptyString2(t *testing.T) {
 }
 
 func TestDiffEmptyString3(t *testing.T) {
-	diff := New("", "b")
+	a := []rune("")
+	b := []rune("b")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{
+	sesExpected := []SesElem[rune]{
 		{e: 'b', t: SesAdd},
 	}
 	assert(t, diff.Editdistance() == 1)
@@ -162,11 +178,13 @@ func TestDiffEmptyString3(t *testing.T) {
 }
 
 func TestDiffMultiByteString(t *testing.T) {
-	diff := New("久保竜彦", "久保達彦")
+	a := []rune("久保竜彦")
+	b := []rune("久保達彦")
+	diff := New[rune](a, b)
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{
+	sesExpected := []SesElem[rune]{
 		{e: '久', t: SesCommon},
 		{e: '保', t: SesCommon},
 		{e: '竜', t: SesDelete},
@@ -179,19 +197,23 @@ func TestDiffMultiByteString(t *testing.T) {
 }
 
 func TestDiffOnlyEditdistance(t *testing.T) {
-	diff := New("abc", "abd")
+	a := []rune("abc")
+	b := []rune("abd")
+	diff := New[rune](a, b)
 	diff.OnlyEd()
 	diff.Compose()
-	lcs := diff.LcsString()
+	lcs := string(diff.Lcs())
 	sesActual := diff.Ses()
-	sesExpected := []SesElem{}
+	sesExpected := []SesElem[rune]{}
 	assert(t, diff.Editdistance() == 2)
 	assert(t, lcs == "")
 	assert(t, equalsSesElemArray(sesActual, sesExpected))
 }
 
 func TestDiffSprintSes(t *testing.T) {
-	diff := New("a\nb\nc", "a\n1\nc")
+	a := []rune("a\nb\nc")
+	b := []rune("a\n1\nc")
+	diff := New[rune](a, b)
 	diff.Compose()
 	ses := diff.SprintSes()
 	assert(t, ses == "  a\n  \n\n- b\n+ 1\n  \n\n  c\n")


### PR DESCRIPTION
## strdiff

```go
diff := gonp.New[rune]([]rune("abc"), []rune("abd"))
diff.Compose()
ed := diff.Editdistance() // ed is 2
lcs := diff.Lcs() // lcs is "ab"
 
ses := diff.Ses()
// ses is []SesElem{
//        {e: 'a', t: Common},
//        {e: 'b', t: Common},
//        {e: 'c', t: Delete},
//        {e: 'd', t: Add},
//        }
```

## intdiff

```go
diff := gonp.New[int]([]int{1,2,3}, []int{1,5,3})
diff.Compose()
ed := diff.Editdistance() // ed is 2
lcs := diff.Lcs() // lcs is [1,3]
 
ses := diff.Ses()
// ses is []SesElem{
//        {e: 1, t: Common},
//        {e: 2, t: Delete},
//        {e: 5, t: Add},
//        {e: 3, t: Common},
//        }
```